### PR TITLE
Fix bug when reg txn date > freq from 'end'

### DIFF
--- a/src/beanahead/reconcile.py
+++ b/src/beanahead/reconcile.py
@@ -554,7 +554,7 @@ def update_new_txns(
     list of Transaction
         `new_txns` as updated. Received order is NOT maintained.
     """
-    for (x_txn, new_txn) in reconciled_x_txns:
+    for x_txn, new_txn in reconciled_x_txns:
         updated_txn = update_new_txn(new_txn, x_txn)
         new_txns.insert(0, updated_txn)
         new_txns.remove(new_txn)

--- a/src/beanahead/rx_txns.py
+++ b/src/beanahead/rx_txns.py
@@ -124,7 +124,7 @@ def create_entries(
     end = END_DFLT if end is None else end
     offset = get_freq_offset(rx_def)
     dates = pd.date_range(rx_def.date, end + offset, freq=offset)
-    if len(dates) == 1:
+    if len(dates) < 2:
         # no txns dated < end (only new definition date was evaluated)
         return ([], None)
     txns = []


### PR DESCRIPTION
Fixes bug for edge case where 'addrx' command raises error if the first date of a new reg txn is greater than the 'end' date (as passed to 'addrx') plus the reg txn's frequency.