### PR TITLE
Update Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile pyproject.toml
 #
-beancount==2.3.5
+beancount==2.3.6
     # via beanahead (pyproject.toml)
 beautifulsoup4==4.12.2
     # via beancount
@@ -16,24 +16,24 @@ certifi==2023.7.22
     # via requests
 chardet==5.2.0
     # via beancount
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 colorama==0.4.6
     # via pytest
 exceptiongroup==1.1.3
     # via pytest
-google-api-core==2.11.1
+google-api-core==2.12.0
     # via google-api-python-client
-google-api-python-client==2.98.0
+google-api-python-client==2.103.0
     # via beancount
-google-auth==2.22.0
+google-auth==2.23.3
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
-google-auth-httplib2==0.1.0
+google-auth-httplib2==0.1.1
     # via google-api-python-client
-googleapis-common-protos==1.60.0
+googleapis-common-protos==1.61.0
     # via google-api-core
 httplib2==0.22.0
     # via
@@ -45,17 +45,19 @@ iniconfig==2.0.0
     # via pytest
 lxml==4.9.3
     # via beancount
-numpy==1.25.2
+numpy==1.26.1
     # via pandas
-packaging==23.1
+packaging==23.2
     # via pytest
-pandas==2.1.0
+pandas==2.1.1
     # via beanahead (pyproject.toml)
+pdfminer2==20151206
+    # via beancount
 pluggy==1.3.0
     # via pytest
 ply==3.11
     # via beancount
-protobuf==4.24.3
+protobuf==4.24.4
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -83,8 +85,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
-    #   google-auth
-    #   google-auth-httplib2
+    #   pdfminer2
     #   python-dateutil
 soupsieve==2.5
     # via beautifulsoup4
@@ -94,7 +95,5 @@ tzdata==2023.3
     # via pandas
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.16
-    # via
-    #   google-auth
-    #   requests
+urllib3==2.0.6
+    # via requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=dev --output-file=requirements_dev.txt pyproject.toml
 #
-astroid==2.15.6
+astroid==3.0.0
     # via pylint
-beancount==2.3.5
+beancount==2.3.6
     # via beanahead (pyproject.toml)
 beautifulsoup4==4.12.2
     # via beancount
-black==23.9.0
+black==23.9.1
     # via beanahead (pyproject.toml)
 bottle==0.12.25
     # via beancount
@@ -24,7 +24,7 @@ cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via beancount
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via
@@ -42,7 +42,7 @@ distlib==0.3.7
     # via virtualenv
 exceptiongroup==1.1.3
     # via pytest
-filelock==3.12.3
+filelock==3.12.4
     # via virtualenv
 flake8==6.1.0
     # via
@@ -50,24 +50,24 @@ flake8==6.1.0
     #   flake8-docstrings
 flake8-docstrings==1.7.0
     # via beanahead (pyproject.toml)
-google-api-core==2.11.1
+google-api-core==2.12.0
     # via google-api-python-client
-google-api-python-client==2.98.0
+google-api-python-client==2.103.0
     # via beancount
-google-auth==2.22.0
+google-auth==2.23.3
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
-google-auth-httplib2==0.1.0
+google-auth-httplib2==0.1.1
     # via google-api-python-client
-googleapis-common-protos==1.60.0
+googleapis-common-protos==1.61.0
     # via google-api-core
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-identify==2.5.27
+identify==2.5.30
     # via pre-commit
 idna==3.4
     # via requests
@@ -77,15 +77,13 @@ iniconfig==2.0.0
     # via pytest
 isort==5.12.0
     # via pylint
-lazy-object-proxy==1.9.0
-    # via astroid
 lxml==4.9.3
     # via beancount
 mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.5.1
+mypy==1.6.0
     # via beanahead (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -93,20 +91,22 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.8.0
     # via pre-commit
-numpy==1.25.2
+numpy==1.26.1
     # via pandas
-packaging==23.1
+packaging==23.2
     # via
     #   black
     #   build
     #   pytest
-pandas==2.1.0
+pandas==2.1.1
     # via beanahead (pyproject.toml)
 pathspec==0.11.2
     # via black
+pdfminer2==20151206
+    # via beancount
 pip-tools==7.3.0
     # via beanahead (pyproject.toml)
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via
     #   black
     #   pylint
@@ -115,9 +115,9 @@ pluggy==1.3.0
     # via pytest
 ply==3.11
     # via beancount
-pre-commit==3.4.0
+pre-commit==3.5.0
     # via beanahead (pyproject.toml)
-protobuf==4.24.3
+protobuf==4.24.4
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -127,13 +127,13 @@ pyasn1==0.5.0
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.1.0
     # via flake8
-pylint==2.17.5
+pylint==3.0.1
     # via beanahead (pyproject.toml)
 pyparsing==3.1.1
     # via httplib2
@@ -159,8 +159,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
-    #   google-auth
-    #   google-auth-httplib2
+    #   pdfminer2
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -177,28 +176,23 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.1
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   astroid
     #   black
-    #   filelock
     #   mypy
     #   pylint
 tzdata==2023.3
     # via pandas
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.16
-    # via
-    #   google-auth
-    #   requests
+urllib3==2.0.6
+    # via requests
 virtualenv==20.24.5
     # via pre-commit
 wheel==0.41.2
     # via pip-tools
-wrapt==1.15.0
-    # via astroid
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --extra=tests --output-file=requirements_tests.txt pyproject.toml
 #
-beancount==2.3.5
+beancount==2.3.6
     # via beanahead (pyproject.toml)
 beautifulsoup4==4.12.2
     # via beancount
-black==23.9.0
+black==23.9.1
     # via beanahead (pyproject.toml)
 bottle==0.12.25
     # via beancount
@@ -18,7 +18,7 @@ certifi==2023.7.22
     # via requests
 chardet==5.2.0
     # via beancount
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via black
@@ -34,18 +34,18 @@ flake8==6.1.0
     #   flake8-docstrings
 flake8-docstrings==1.7.0
     # via beanahead (pyproject.toml)
-google-api-core==2.11.1
+google-api-core==2.12.0
     # via google-api-python-client
-google-api-python-client==2.98.0
+google-api-python-client==2.103.0
     # via beancount
-google-auth==2.22.0
+google-auth==2.23.3
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
-google-auth-httplib2==0.1.0
+google-auth-httplib2==0.1.1
     # via google-api-python-client
-googleapis-common-protos==1.60.0
+googleapis-common-protos==1.61.0
     # via google-api-core
 httplib2==0.22.0
     # via
@@ -61,23 +61,25 @@ mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-numpy==1.25.2
+numpy==1.26.1
     # via pandas
-packaging==23.1
+packaging==23.2
     # via
     #   black
     #   pytest
-pandas==2.1.0
+pandas==2.1.1
     # via beanahead (pyproject.toml)
 pathspec==0.11.2
     # via black
-platformdirs==3.10.0
+pdfminer2==20151206
+    # via beancount
+platformdirs==3.11.0
     # via black
 pluggy==1.3.0
     # via pytest
 ply==3.11
     # via beancount
-protobuf==4.24.3
+protobuf==4.24.4
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -87,7 +89,7 @@ pyasn1==0.5.0
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
@@ -113,8 +115,7 @@ rsa==4.9
     # via google-auth
 six==1.16.0
     # via
-    #   google-auth
-    #   google-auth-httplib2
+    #   pdfminer2
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -124,13 +125,11 @@ tomli==2.0.1
     # via
     #   black
     #   pytest
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via black
 tzdata==2023.3
     # via pandas
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.16
-    # via
-    #   google-auth
-    #   requests
+urllib3==2.0.6
+    # via requests

--- a/tests/resources/defs/rx_221231.beancount
+++ b/tests/resources/defs/rx_221231.beancount
@@ -93,8 +93,8 @@ pushtag #rx_txn
   Liabilities:US:Chase:Slate
 
 2022-10-31 * "Chase" "Chase Hire Purchase"
-  final: 2022-11-30
   freq: "BM"
+  final: 2022-11-30
   Liabilities:US:Chase:HirePurchase  322.00 USD
   Assets:US:BofA:Checking
 
@@ -199,8 +199,8 @@ pushtag #rx_txn
   Liabilities:US:Chase:Slate
 
 2022-11-30 * "Chase" "Chase Hire Purchase"
-  final: 2022-11-30
   freq: "BM"
+  final: 2022-11-30
   Liabilities:US:Chase:HirePurchase  322.00 USD
   Assets:US:BofA:Checking
 

--- a/tests/resources/defs/rx_230630.beancount
+++ b/tests/resources/defs/rx_230630.beancount
@@ -93,8 +93,8 @@ pushtag #rx_txn
   Liabilities:US:Chase:Slate
 
 2022-10-31 * "Chase" "Chase Hire Purchase"
-  final: 2022-11-30
   freq: "BM"
+  final: 2022-11-30
   Liabilities:US:Chase:HirePurchase  322.00 USD
   Assets:US:BofA:Checking
 
@@ -199,8 +199,8 @@ pushtag #rx_txn
   Liabilities:US:Chase:Slate
 
 2022-11-30 * "Chase" "Chase Hire Purchase"
-  final: 2022-11-30
   freq: "BM"
+  final: 2022-11-30
   Liabilities:US:Chase:HirePurchase  322.00 USD
   Assets:US:BofA:Checking
 

--- a/tests/resources/recon/expected_injection.beancount
+++ b/tests/resources/recon/expected_injection.beancount
@@ -1,14 +1,14 @@
 ;; -*- mode: beancount -*-
 
 2022-10-03 * "Account Fee" "Monthly bank fee"
-  matches: "1"
   tid: "1"
+  matches: "1"
   Assets:US:BofA:Checking  -4.00 USD
   Expenses:Financial:Fees
 
 2022-10-03 * "Jewel of Morroco" "Eating out with work buddies"
-  matches: "50"
   tid: "50"
+  matches: "50"
   Liabilities:US:Chase:Slate  -71.42 USD
   Expenses:Food:Restaurant
 
@@ -17,14 +17,14 @@
   Liabilities:US:Chase:Slate  -20.00 USD
 
 2022-10-05 * "Edison Power green tariff" "Electricity, monthly fixed tarrif"
-  matches: "2"
   tid: "2"
+  matches: "2"
   Assets:US:BofA:Checking    -65.00 USD
   Expenses:Home:Electricity
 
 2022-10-07 * "BayBook 2022-09-23 through 2022-10-06" "Payroll"
-  matches: "3"
   tid: "3"
+  matches: "3"
   Assets:US:BofA:Checking                      1350.60 USD
   Assets:US:Vanguard:Cash                      1200.00 USD
   Income:US:BayBook:Salary                    -4615.38 USD
@@ -45,39 +45,39 @@
   Income:US:BayBook:Vacation                        -5 VACHR
 
 2022-10-07 * "VBMPX" "Investing 40% of cash in VBMPX"
-  matches: "8"
   tid: "8"
+  matches: "8"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:VBMPX  49.42 VBMPX @ 9.7115 USD
 
 2022-10-07 * "RGAGX" "Investing 60% of cash in RGAGX"
-  matches: "9"
   tid: "9"
+  matches: "9"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:RGAGX  12.84 RGAGX @ 56.0763 USD
 
 2022-10-15 * "Goba Goba" "Eating out after work"
-  matches: "52"
   tid: "52"
+  matches: "52"
   Liabilities:US:Chase:Slate  -40.00 USD
   Expenses:Food:Restaurant
 
 2022-10-17 * "Verizon Mobile" "Telecoms, monthly variable" #you-can-inc-tags
-  matches: "4"
   tid: "4"
+  matches: "4"
   Assets:US:BofA:Checking  -72.63 USD
   Expenses:Home:Phone
 
 2022-10-17 * "Metro Transport Authority" "Tram tickets, Metro Authority"
+  tid: "12"
   matches: "12"
   test_meta: "You can include meta fields"
-  tid: "12"
   Liabilities:US:Chase:Slate  -120.00 USD
   Expenses:Transport:Tram
 
 2022-10-21 * "BayBook 2022-10-07 through 2022-10-20" "Payroll"
-  matches: "5"
   tid: "5"
+  matches: "5"
   Assets:US:BofA:Checking                      1350.60 USD
   Assets:US:Vanguard:Cash                      1200.00 USD
   Income:US:BayBook:Salary                    -4615.38 USD
@@ -98,14 +98,14 @@
   Income:US:BayBook:Vacation                        -5 VACHR
 
 2022-10-21 * "VBMPX" "Investing 40% of cash in VBMPX"
-  matches: "10"
   tid: "10"
+  matches: "10"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:VBMPX  49.13 VBMPX @ 9.7688 USD
 
 2022-10-21 * "RGAGX" "Investing 60% of cash in RGAGX"
-  matches: "11"
   tid: "11"
+  matches: "11"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:RGAGX  12.78 RGAGX @ 56.3396 USD
 
@@ -126,20 +126,20 @@
   Liabilities:US:Chase:Slate  -20.20 USD
 
 2022-10-25 * "Chichipotle" "Eating out with Natasha"
-  matches: "55, 54, 53"
   tid: "55"
+  matches: "55, 54, 53"
   Liabilities:US:Chase:Slate  -33.01 USD
   Expenses:Food:Restaurant
 
 2022-10-25 * "Kin Soy" "Eating out with Bill"
-  matches: "56, 57, 58"
   tid: "58"
+  matches: "56, 57, 58"
   Liabilities:US:Chase:Slate  -20.00 USD
   Expenses:Food:Restaurant
 
 2022-10-29 * "25 Degrees Burger Bar" "The only one of three that was included to expected txns"
-  matches: "59, 60"
   tid: "59"
+  matches: "59, 60"
   Liabilities:US:Chase:Slate  -8.00 USD
   Expenses:Food:Restaurant
 
@@ -152,22 +152,22 @@
   Liabilities:US:Chase:Slate  -8.00 USD
 
 2022-10-30 * "Mercadito" "Alcohol on 62 should be 40, coffee 8, restaurant empty"
-  matches: "62"
   tid: "62"
+  matches: "62"
   Liabilities:US:Chase:Slate  -102.93 USD
   Expenses:Food:Alcohol        -40.00 USD
   Expenses:Food:Coffee          -8.00 USD
   Expenses:Food:Restaurant
 
 2022-10-31 * "Chase Bank Slate" "Credit Card payment"
-  matches: "6"
   tid: "6"
+  matches: "6"
   Assets:US:BofA:Checking     -461.00 USD
   Liabilities:US:Chase:Slate   461.00 USD
 
 2022-10-31 * "Chase Hire Purchase" "Chase Hire Purchase"
-  matches: "7"
   tid: "7"
+  matches: "7"
   Liabilities:US:Chase:HirePurchase   324.61 USD
   Assets:US:BofA:Checking            -324.61 USD
 

--- a/tests/resources/recon/expected_injection_ascending.beancount
+++ b/tests/resources/recon/expected_injection_ascending.beancount
@@ -5,20 +5,20 @@
 2022-11-01 balance Assets:US:BofA:Checking                         5320.22 USD
 
 2022-10-31 * "Chase Hire Purchase" "Chase Hire Purchase"
-  matches: "7"
   tid: "7"
+  matches: "7"
   Liabilities:US:Chase:HirePurchase   324.61 USD
   Assets:US:BofA:Checking            -324.61 USD
 
 2022-10-31 * "Chase Bank Slate" "Credit Card payment"
-  matches: "6"
   tid: "6"
+  matches: "6"
   Assets:US:BofA:Checking     -461.00 USD
   Liabilities:US:Chase:Slate   461.00 USD
 
 2022-10-30 * "Mercadito" "Alcohol on 62 should be 40, coffee 8, restaurant empty"
-  matches: "62"
   tid: "62"
+  matches: "62"
   Liabilities:US:Chase:Slate  -102.93 USD
   Expenses:Food:Alcohol        -40.00 USD
   Expenses:Food:Coffee          -8.00 USD
@@ -33,20 +33,20 @@
   Liabilities:US:Chase:Slate  -8.00 USD
 
 2022-10-29 * "25 Degrees Burger Bar" "The only one of three that was included to expected txns"
-  matches: "59, 60"
   tid: "59"
+  matches: "59, 60"
   Liabilities:US:Chase:Slate  -8.00 USD
   Expenses:Food:Restaurant
 
 2022-10-25 * "Kin Soy" "Eating out with Bill"
-  matches: "56, 57, 58"
   tid: "58"
+  matches: "56, 57, 58"
   Liabilities:US:Chase:Slate  -20.00 USD
   Expenses:Food:Restaurant
 
 2022-10-25 * "Chichipotle" "Eating out with Natasha"
-  matches: "55, 54, 53"
   tid: "55"
+  matches: "55, 54, 53"
   Liabilities:US:Chase:Slate  -33.01 USD
   Expenses:Food:Restaurant
 
@@ -67,20 +67,20 @@
   Liabilities:US:Chase:Slate  -77.60 USD
 
 2022-10-21 * "RGAGX" "Investing 60% of cash in RGAGX"
-  matches: "11"
   tid: "11"
+  matches: "11"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:RGAGX  12.78 RGAGX @ 56.3396 USD
 
 2022-10-21 * "VBMPX" "Investing 40% of cash in VBMPX"
-  matches: "10"
   tid: "10"
+  matches: "10"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:VBMPX  49.13 VBMPX @ 9.7688 USD
 
 2022-10-21 * "BayBook 2022-10-07 through 2022-10-20" "Payroll"
-  matches: "5"
   tid: "5"
+  matches: "5"
   Assets:US:BofA:Checking                      1350.60 USD
   Assets:US:Vanguard:Cash                      1200.00 USD
   Income:US:BayBook:Salary                    -4615.38 USD
@@ -101,39 +101,39 @@
   Income:US:BayBook:Vacation                        -5 VACHR
 
 2022-10-17 * "Metro Transport Authority" "Tram tickets, Metro Authority"
+  tid: "12"
   matches: "12"
   test_meta: "You can include meta fields"
-  tid: "12"
   Liabilities:US:Chase:Slate  -120.00 USD
   Expenses:Transport:Tram
 
 2022-10-17 * "Verizon Mobile" "Telecoms, monthly variable" #you-can-inc-tags
-  matches: "4"
   tid: "4"
+  matches: "4"
   Assets:US:BofA:Checking  -72.63 USD
   Expenses:Home:Phone
 
 2022-10-15 * "Goba Goba" "Eating out after work"
-  matches: "52"
   tid: "52"
+  matches: "52"
   Liabilities:US:Chase:Slate  -40.00 USD
   Expenses:Food:Restaurant
 
 2022-10-07 * "RGAGX" "Investing 60% of cash in RGAGX"
-  matches: "9"
   tid: "9"
+  matches: "9"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:RGAGX  12.84 RGAGX @ 56.0763 USD
 
 2022-10-07 * "VBMPX" "Investing 40% of cash in VBMPX"
-  matches: "8"
   tid: "8"
+  matches: "8"
   Assets:US:Vanguard:Cash
   Assets:US:Vanguard:VBMPX  49.42 VBMPX @ 9.7115 USD
 
 2022-10-07 * "BayBook 2022-09-23 through 2022-10-06" "Payroll"
-  matches: "3"
   tid: "3"
+  matches: "3"
   Assets:US:BofA:Checking                      1350.60 USD
   Assets:US:Vanguard:Cash                      1200.00 USD
   Income:US:BayBook:Salary                    -4615.38 USD
@@ -154,8 +154,8 @@
   Income:US:BayBook:Vacation                        -5 VACHR
 
 2022-10-05 * "Edison Power green tariff" "Electricity, monthly fixed tarrif"
-  matches: "2"
   tid: "2"
+  matches: "2"
   Assets:US:BofA:Checking    -65.00 USD
   Expenses:Home:Electricity
 
@@ -164,13 +164,13 @@
   Liabilities:US:Chase:Slate  -20.00 USD
 
 2022-10-03 * "Jewel of Morroco" "Eating out with work buddies"
-  matches: "50"
   tid: "50"
+  matches: "50"
   Liabilities:US:Chase:Slate  -71.42 USD
   Expenses:Food:Restaurant
 
 2022-10-03 * "Account Fee" "Monthly bank fee"
-  matches: "1"
   tid: "1"
+  matches: "1"
   Assets:US:BofA:Checking  -4.00 USD
   Expenses:Financial:Fees


### PR DESCRIPTION
Also updates test resources expected content files to reflect parsing changes in `beancount` 2.3.6. Meta data is now ordered as defined. Previously (seems that) was ordered alphanumerically.