### PR TITLE
Include option to stream print to stderr

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,6 @@
 # usually to register additional checkers.
 load-plugins=pylint.extensions.broad_try_clause,
              pylint.extensions.confusing_elif,
-             pylint.extensions.comparetozero,
              pylint.extensions.bad_builtin,
              pylint.extensions.mccabe,
              pylint.extensions.docstyle,

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ subcommands:
 * [Injection](#injection)
 * [Expired expected transactions](#expired-expected-transactions)
 * [Worth remembering](#worth-remembering)
+* [Developers](#developers)
 * [Alternative packages](#alternative-packages)
 * [beancount recommendations](#beancount-recommendations)
 * [Licence](#license)
@@ -374,6 +375,19 @@ With a bit of luck and perhaps a tweak or two to your ledger, your `bean-check` 
 
 ## Worth remembering
 > :warning: Whenever an expected transactions ledger or the regular expected transaction definition files are updated the entries are resorted and the file is overwritten - anything that is not a directive (e.g. comments) will be lost. 
+
+## Developers
+If you are employing a workflow that directs output through `sys.stdout` then this will merge with Beanahead's own output to this stream. To avoid such conflicts `beanahead` provides for directing its output to `sys.stderr`. This can be set from the command line by preceeding any subcommand with --print_stderr, for example...
+```
+$ beanahead --print_stderr exp rx x
+```
+The same effect can be achieved with the flag -p.
+```
+$ beanahead -p exp rx x
+```
+If using the underlying functions directly in the codebase then the print stream can be set via the following methods of the `beanahead.config` module:
+- `set_print_stderr()`
+- `set_print_stdout()`
 
 ## Alternative packages
 The beancount community offers a considerable array of add-on packages, many of which are well-rated and maintained. Below I've noted those I know of with functionality that includes some of what `beanahead` offers. Which package you're likely to find most useful will come down to your specific circumstances and requirements - horses for courses.

--- a/src/beanahead/config.py
+++ b/src/beanahead/config.py
@@ -1,0 +1,22 @@
+"""Configuration file for options."""
+
+import sys
+
+_print_stdout = True
+
+
+def set_print_stdout():
+    """Set output stream for print to stdout."""
+    global _print_stdout
+    _print_stdout = True
+
+
+def set_print_stderr():
+    """Set output stream for print to stderr."""
+    global _print_stdout
+    _print_stdout = False
+
+
+def get_print_file():
+    """Get stream to print to."""
+    return sys.stdout if _print_stdout else sys.stderr

--- a/src/beanahead/expired.py
+++ b/src/beanahead/expired.py
@@ -123,7 +123,7 @@ def _update_txn(txn: Transaction, path: Path) -> Transaction | None:
         None if user choose to remove.
         Otherwise a new Transaction object with revised date.
     """
-    print(
+    utils.print_it(
         f"{utils.SEPARATOR_LINE}\nThe following transaction has expired."
         f"\n\n{utils.compose_entries_content(txn)}"
         f"\n0 Move transaction forwards to tomorrow ({TOMORROW})."
@@ -245,7 +245,7 @@ def admin_expired_txns(ledgers: list[str]):
 
     if no_expired_txns:
         paths_string = "\n".join([str(path) for path in paths])
-        print(
+        utils.print_it(
             "There are no expired transactions on any of the following"
             f" ledgers:\n{paths_string}"
         )
@@ -254,7 +254,7 @@ def admin_expired_txns(ledgers: list[str]):
     updated_paths = [path for path in paths if ledger_updated[path]]
     paths_string = "\n".join([str(path) for path in updated_paths])
     if not updated_paths:
-        print(
+        utils.print_it(
             "\nYou have not choosen to modify any expired transactions."
             "\nNo ledger has been altered."
         )
@@ -266,4 +266,4 @@ def admin_expired_txns(ledgers: list[str]):
         updated_contents[path] = content
 
     overwrite_ledgers(updated_contents)
-    print(f"\nThe following ledgers have been updated:\n{paths_string}")
+    utils.print_it(f"\nThe following ledgers have been updated:\n{paths_string}")

--- a/src/beanahead/rx_txns.py
+++ b/src/beanahead/rx_txns.py
@@ -651,7 +651,9 @@ class Admin:
 
         new_txns, new_defs = self._get_new_txns_data(end)
         if not new_txns:
-            print(f"There are no new Regular Expected Transactions to add with {end=}.")
+            utils.print_it(
+                f"There are no new Regular Expected Transactions to add with {end=}."
+            )
             return
 
         ledger_txns = self.rx_txns + new_txns
@@ -664,7 +666,7 @@ class Admin:
         also_revert = [self.path_ledger]
         self._overwrite_beancount_file(self.path_defs, content_defs, also_revert)
         self._validate_main_ledger(self.rx_files)
-        print(
+        utils.print_it(
             f"{len(new_txns)} transactions have been added to the ledger"
             f" '{self.path_ledger.stem}'.\nDefinitions on '{self.path_defs.stem}' have"
             f" been updated to reflect the most recent transactions."

--- a/src/beanahead/scripts/cli.py
+++ b/src/beanahead/scripts/cli.py
@@ -11,7 +11,7 @@ import argparse
 import datetime
 
 import beanahead
-from beanahead import utils, rx_txns, reconcile, expired
+from beanahead import utils, rx_txns, reconcile, expired, config
 
 
 def make_file(args: argparse.Namespace):
@@ -59,6 +59,16 @@ def main():
 
     parser.add_argument(
         "--version", "-V", action="version", version=beanahead.__version__
+    )
+
+    parser.add_argument(
+        *["-p", "--print_stderr"],
+        action="store_true",
+        help=(
+            "send any print to stderr rather than stdoud (this can"
+            "\nbe useful if the client wishes to use stdout for another"
+            "\npurpose)"
+        ),
     )
 
     subparsers = parser.add_subparsers(
@@ -259,7 +269,12 @@ def main():
 
     # Call pass-through function corresponding with subcommand
     args = parser.parse_args()
+
+    # Set print stream and revert to stdout
+    if args.print_stderr:
+        config.set_print_stderr()
     args.func(args)
+    config.set_print_stdout()
 
 
 if __name__ == "__main__":

--- a/src/beanahead/utils.py
+++ b/src/beanahead/utils.py
@@ -15,6 +15,7 @@ from beancount.core.interpolate import AUTOMATIC_META
 from beangulp.extract import HEADER
 from beancount.parser import parser, printer
 
+from . import config
 from .errors import (
     BeancountFileExistsError,
     BeanaheadFileExistsError,
@@ -66,6 +67,21 @@ FILE_CONFIG = {
 }
 
 LEDGER_FILE_KEYS = ["x", "rx"]
+
+
+def print_it(text: str, **kwargs):
+    """Print to the selected stream.
+
+    Parameters
+    ----------
+    text
+        Text to print.
+
+    kwargs
+        Kwargs to pass to 'print' function.
+    """
+    kwargs["file"] = config.get_print_file()
+    print(text, **kwargs)
 
 
 def validate_file_key(file_key: str):
@@ -320,8 +336,8 @@ def get_verified_file_key(path: Path) -> str:
     opts = get_options(path)
     title = opts["title"]
     all_titles = []
-    for file_key, config in FILE_CONFIG.items():
-        if title == (config_title := config["title"]):
+    for file_key, config_ in FILE_CONFIG.items():
+        if title == (config_title := config_["title"]):
             return file_key
         all_titles.append(config_title)
     titles_string = "\n".join(all_titles)
@@ -845,7 +861,8 @@ def get_input(text: str) -> str:
     -----
     Function included to facilitate mocking user input when testing.
     """
-    return input(text)
+    print_it(text, end=": ")
+    return input()
 
 
 def response_is_valid_number(response: str, max_value: int) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import beancount
 from beancount.core import data
 import pytest
 
+from beanahead import utils
 
 # pylint: disable=missing-function-docstring, missing-type-doc
 # pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
@@ -71,11 +72,19 @@ def get_expected_output(string: str):
 
 
 def also_get_stdout(f: abc.Callable, *args, **kwargs) -> tuple[typing.Any, str]:
-    """Return a function's return together with output to stdout."""
-    stdout = io.StringIO()
-    with contextlib.redirect_stdout(stdout):
+    """Return a function's return together with print to stdout."""
+    prnt = io.StringIO()
+    with contextlib.redirect_stdout(prnt):
         rtrn = f(*args, **kwargs)
-    return rtrn, stdout.getvalue()
+    return rtrn, prnt.getvalue()
+
+
+def also_get_stderr(f: abc.Callable, *args, **kwargs) -> tuple[typing.Any, str]:
+    """Return a function's return together with print to stderr."""
+    prnt = io.StringIO()
+    with contextlib.redirect_stderr(prnt):
+        rtrn = f(*args, **kwargs)
+    return rtrn, prnt.getvalue()
 
 
 @pytest.fixture
@@ -132,7 +141,7 @@ def mock_input(monkeypatch) -> abc.Iterator:
             monkeypatch.setattr("beanahead.utils.get_input", self.input)
 
         def input(self, string: str) -> str:
-            print(string)
+            utils.print_it(string)
             return next(self.responses)
 
     yield MockInput

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for `config` module."""
+
+import sys
+
+from beanahead import config as m
+
+from .conftest import also_get_stdout, also_get_stderr
+
+# pylint: disable=missing-function-docstring, missing-type-doc, missing-class-docstring
+# pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
+# pylint: disable=too-many-public-methods, too-many-arguments, too-many-locals
+# pylint: disable=too-many-statements
+# pylint: disable=protected-access, line-too-long, unused-argument, invalid-name
+#   missing-fuction-docstring: doc not required for all tests
+#   protected-access: not required for tests
+#   not compatible with use of fixtures to parameterize tests:
+#       too-many-arguments, too-many-public-methods
+#   not compatible with pytest fixtures:
+#       redefined-outer-name, missing-any-param-doc, missing-type-doc
+#   unused-argument: not compatible with pytest fixtures, caught by pylance anyway.
+#   invalid-name: names in tests not expected to strictly conform with snake_case.
+
+
+def test_print_stream():
+    """Tests output of print stream between stdout and stderr."""
+    assert m._print_stdout is True
+    assert m.get_print_file() is sys.stdout
+
+    def print_something():
+        print("something", file=m.get_print_file())
+
+    _, prnt = also_get_stdout(print_something)
+    assert prnt == "something\n"
+    _, prnt = also_get_stderr(print_something)
+    assert not prnt
+
+    m.set_print_stderr()
+    _, prnt = also_get_stdout(print_something)
+    assert not prnt
+    _, prnt = also_get_stderr(print_something)
+    assert prnt == "something\n"
+
+    m.set_print_stdout()
+    _, prnt = also_get_stdout(print_something)
+    assert prnt == "something\n"
+    _, prnt = also_get_stderr(print_something)
+    assert not prnt

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,9 +15,15 @@ from beanahead.scripts import cli
 import pytest
 
 from beanahead import utils as m
-from beanahead import errors
+from beanahead import errors, config
 
-from .conftest import get_fileobj, set_cl_args, get_expected_output
+from .conftest import (
+    get_fileobj,
+    set_cl_args,
+    get_expected_output,
+    also_get_stderr,
+    also_get_stdout,
+)
 from . import cmn
 
 # pylint: disable=missing-function-docstring, missing-type-doc, missing-class-docstring
@@ -226,6 +232,31 @@ def test_constants(tag_x, tag_rx, file_keys, ledger_file_keys, encoding):
         assert m.FILE_CONFIG[file_key]["tag"] == tag_rx
 
     assert set(m.LEDGER_FILE_KEYS) == ledger_file_keys
+
+
+def test_print_it():
+    def print_something():
+        m.print_it("something")
+
+    _, prnt = also_get_stdout(print_something)
+    assert prnt == "something\n"
+    _, prnt = also_get_stderr(print_something)
+    assert not prnt
+
+    config.set_print_stderr()
+    _, prnt = also_get_stdout(print_something)
+    assert not prnt
+    _, prnt = also_get_stderr(print_something)
+    assert prnt == "something\n"
+
+    def print_something_else():
+        m.print_it("something else", end=":")  # Verify can pass through kwargs
+
+    config.set_print_stdout()
+    _, prnt = also_get_stdout(print_something_else)
+    assert prnt == "something else:"
+    _, prnt = also_get_stderr(print_something_else)
+    assert not prnt
 
 
 def test_validate_file_key(file_keys):


### PR DESCRIPTION
Directs all print output through new `utils.print_it` function. In turn that prints to either stdout (default) or stderr. Stream can be set via methods on new `config.py` module:
- `set_print_stderr()`
- `set_print_stdout()`

Also, can set print stream to stderr via cli with --print_stderr or -p flags.

Tests included.
Documented to README to new 'Developers' section (see there for reasoning).