### PR TITLE
Add support for custom name options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ $ beanahead make x -f x
 ```
 include "x.beancount"
 ```
-
 So, if you want to include both regular and ad hoc expected transactions then you should have created three new `.beancount` files and added two 'include' lines to top of your main ledger.
 
 > :information_source: The -f option provides for defining the filename (`make` will add the `.beancount` extension). If -f is not passed then default names will be used which are as those explicitly passed in the examples.
@@ -111,12 +110,15 @@ The [examples/new_empty_files](./examples/new_empty_files) folder includes a sam
 - [Regular Expected Transactions Ledger](./examples/new_empty_files/rx.beancount)
 - [Expected Transactions Ledger](./examples/new_empty_files/x.beancount)
 
-## Regular Expected Transactions
+NB If you're not using the default account root names (e.g. 'Assets', 'Income', 'Expenses' etc) then you'll also need to use the optional --main argument to provide the path to a ledger from which beanahead can read the customised name options. Example:
+```
+$ beanahead make x -f x --main my_ledger
+```
 
+## Regular Expected Transactions
 Regular expected transactions are defined on the Regular Expected Transaction _Definitions_ file. The `addrx` command can then be used to populate the Regular Expected Transactions _Ledger_ with transactions generated from these definitions.
 
 ### Defining regular transactions
-
 A new regular transaction can be defined at any time by adding a single transaction to the definitions file (the 'initial definition'). The date of this transaction will serve as the anchor off which future transactions are evaluated.
 
 The following initial definition would generate regular transactions on the 5th of every month, with the first generated transaction dated 2022-10-05. 
@@ -376,7 +378,8 @@ With a bit of luck and perhaps a tweak or two to your ledger, your `bean-check` 
 ## Worth remembering
 > :warning: Whenever an expected transactions ledger or the regular expected transaction definition files are updated the entries are resorted and the file is overwritten - anything that is not a directive (e.g. comments) will be lost. 
 
-## Developers
+## Options
+### Print to stderr
 If you are employing a workflow that directs output through `sys.stdout` then this will merge with Beanahead's own output to this stream. To avoid such conflicts `beanahead` provides for directing its output to `sys.stderr`. This can be set from the command line by preceeding any subcommand with --print_stderr, for example...
 ```
 $ beanahead --print_stderr exp rx x
@@ -388,6 +391,15 @@ $ beanahead -p exp rx x
 If using the underlying functions directly in the codebase then the print stream can be set via the following methods of the `beanahead.config` module:
 - `set_print_stderr()`
 - `set_print_stdout()`
+
+### Custom account root names
+If you're not using the default account root names (e.g. 'Assets', 'Income', 'Expenses' etc) then beanahead will need to know the values that you are using.
+
+The subcommands of the cli that require these names get them from a ledger ('addrx' will read them from the main ledger which is a required argument, 'make' will read them from any ledger passed to its optional --main argument).
+
+If using the underlying functions directly in the codebase then the names can be set either by passing a dictionary to `config.set_account_root_names` or by passing a ledger that contains these options to `utils.set_account_root_names`.
+
+The currently set names can be inspected via `config.get_account_root_names()` and reset to the default values with`config.reset_account_root_names()`.
 
 ## Alternative packages
 The beancount community offers a considerable array of add-on packages, many of which are well-rated and maintained. Below I've noted those I know of with functionality that includes some of what `beanahead` offers. Which package you're likely to find most useful will come down to your specific circumstances and requirements - horses for courses.

--- a/src/beanahead/config.py
+++ b/src/beanahead/config.py
@@ -5,6 +5,11 @@ import sys
 _print_stdout = True
 
 
+def get_print_file():
+    """Get stream to print to."""
+    return sys.stdout if _print_stdout else sys.stderr
+
+
 def set_print_stdout():
     """Set output stream for print to stdout."""
     global _print_stdout
@@ -17,6 +22,85 @@ def set_print_stderr():
     _print_stdout = False
 
 
-def get_print_file():
-    """Get stream to print to."""
-    return sys.stdout if _print_stdout else sys.stderr
+DEFAULT_ACCOUNT_ROOT_NAMES = {
+    "name_assets": "Assets",
+    "name_liabilities": "Liabilities",
+    "name_equity": "Equity",
+    "name_income": "Income",
+    "name_expenses": "Expenses",
+}
+
+_account_root_names = DEFAULT_ACCOUNT_ROOT_NAMES.copy()
+
+
+def get_account_root_names() -> dict[str, str]:
+    """Get account root names."""
+    return _account_root_names.copy()
+
+
+def set_account_root_names(names: dict) -> dict[str, str]:
+    """Set account root names.
+
+    Use this method to set the account root names.
+
+    Default account root names that otherwise prevail are:
+    {
+        'name_assets': 'Assets',
+        'name_liabilities': 'Liabilities',
+        'name_equity': 'Equity',
+        'name_income': 'Income',
+        'name_expenses': 'Expenses',
+    }
+
+    Parameters
+    ----------
+    names
+        Dictionary with:
+            keys: str
+                Any of the account root name options {'name_assets',
+                'name_expenses', 'name_income', 'name_liabilities',
+                'name_equity'}
+
+            values: str
+                Corresponding account root name.
+
+    Returns
+    -------
+    account_root_names: dict[str, str]
+        Newly set account root names.
+    """
+    global _account_root_names
+    diff = set(names) - set(_account_root_names)
+    if diff:
+        raise ValueError(
+            f"'names' parameter can only contain keys: {set(_account_root_names)},"
+            f" although received 'names' included keys: {diff}"
+        )
+    _account_root_names |= names
+    set_names = get_account_root_names()
+    assert _account_root_names == set_names
+    return set_names
+
+
+def reset_account_root_names() -> dict[str, str]:
+    """Set account root names to default values.
+
+    Default account root names are:
+    {
+        'name_assets': 'Assets',
+        'name_liabilities': 'Liabilities',
+        'name_equity': 'Equity',
+        'name_income': 'Income',
+        'name_expenses': 'Expenses',
+    }
+
+    Returns
+    -------
+    account_root_names: dict[str, str]
+        Newly set account root names.
+    """
+    global _account_root_names
+    _account_root_names |= DEFAULT_ACCOUNT_ROOT_NAMES
+    set_names = get_account_root_names()
+    assert _account_root_names == set_names
+    return set_names

--- a/src/beanahead/rx_txns.py
+++ b/src/beanahead/rx_txns.py
@@ -17,7 +17,7 @@ from beancount.core.data import Transaction
 from beancount.parser import parser
 from beancount.parser.printer import EntryPrinter
 
-from . import utils, errors
+from . import utils, errors, config
 from .errors import BeanaheadWriteError, BeancountLoaderErrors
 
 END_DFLT = utils.TODAY + datetime.timedelta(weeks=13)
@@ -209,9 +209,9 @@ def get_definition_group(definition: Transaction) -> GrouperKey:
         if account == bal_sheet_account:
             continue
         account_type = get_account_type(account)
-        if account_type == "Assets":
+        if account_type == config.get_account_root_names()["name_assets"]:
             other_sides.add("Assets")
-        elif account_type == "Income":
+        elif account_type == config.get_account_root_names()["name_income"]:
             other_sides.add("Income")
         else:
             other_sides.add("Expenses")

--- a/src/beanahead/scripts/cli.py
+++ b/src/beanahead/scripts/cli.py
@@ -112,8 +112,19 @@ def main():
     parser_make.add_argument(
         *["-f", "--filename"],
         help=(
-            "Name of new beanahead file. By default, as `key`.\nShould not"
-            " include the .beancount extension."
+            "Name of new beanahead file. By default, as `key`."
+            "\nShould not include the .beancount extension."
+        ),
+        metavar="",
+    )
+
+    parser_make.add_argument(
+        *["-m", "--main"],
+        help=(
+            "Path to existing main Ledger file. Only required if\n"
+            "account root names are not the default values, in\n"
+            "which case will use root names as defined by\n"
+            "the options on this ledger.\n"
         ),
         metavar="",
     )
@@ -270,11 +281,18 @@ def main():
     # Call pass-through function corresponding with subcommand
     args = parser.parse_args()
 
-    # Set print stream and revert to stdout
+    # Set print stream
     if args.print_stderr:
         config.set_print_stderr()
+    # Set root account names
+    if "main" in args and args.main is not None:
+        utils.set_account_root_names(args.main)
+
     args.func(args)
+
+    # Revert options to default values
     config.set_print_stdout()
+    config.reset_account_root_names()
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,3 +244,15 @@ def rx_txn_chase(txns_rx) -> abc.Iterator[data.Transaction]:
     assert txn.payee == "Chase"
     assert txn.date == datetime.date(2022, 10, 31)
     yield txn
+
+
+@pytest.fixture
+def account_root_names_dflt() -> abc.Iterator[dict[str, str]]:
+    """Expected default account_root_names."""
+    yield {
+        "name_assets": "Assets",
+        "name_liabilities": "Liabilities",
+        "name_equity": "Equity",
+        "name_income": "Income",
+        "name_expenses": "Expenses",
+    }

--- a/tests/resources/defs/defs_opts.beancount
+++ b/tests/resources/defs/defs_opts.beancount
@@ -1,0 +1,126 @@
+option "title" "Regular Expected Transaction Definitions"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+plugin "rx_txn_plugin"
+pushtag #rx_txn
+;; All accounts referenced by definitions should be defined on the main ledger.
+;; Enter definitions after this line...
+
+* Expenses
+
+2022-10-05 * "EDISON" "Electricity, monthly fixed tarrif"
+  freq: "m"
+  Biens:US:BofA:Checking                     -65.00 USD
+  Expenses:Home:Electricity
+
+2022-10-16 * "Verizon" "Telecoms, monthly variable" #you-can-inc-tags
+  ; 2022-10-16 is a Sunday. By default, the next generated transaction
+  ; will be rolled forwards to 2022-10-17 (Monday) although transactions
+  ; thereafter will be dated the 15 of each month whenever the 15 is a
+  ; weekday.
+  ; Also serves to test that definitions update to a non-rolled
+  ; transaction - updated definition following adding rx txns through to
+  ; 2023-06-30 should update this definition to have date 2023-07-16,
+  ; which is a Sunday. 
+  freq: "m"
+  Biens:US:BofA:Checking                     -55.00 USD
+  Expenses:Home:Phone
+
+2023-04-18 * "Erie" "Home insurance, yearly premium"
+  freq: "y" ; annual frequency
+  Biens:US:BofA:Checking                    -427.60 USD
+  Expenses:Home:Insurance
+
+
+* Define frequency as a pandas frequency
+
+2022-10-01 * "Account Fee" "Monthly bank fee"
+  freq: "BMS" ; date transactions as first business day of each month
+  Biens:US:BofA:Checking                      -4.00 USD
+  Expenses:Financial:Fees
+
+2022-10-31 * "Slate" "Credit Card payment"
+  freq: "BME" ; date transactions as last business day of each month
+  Biens:US:BofA:Checking                     -250.00 USD
+  Liabilities:US:Chase:Slate
+
+2022-10-15 * "Metro" "Tram tickets, Metro Authority"
+  ; Also serves to test that definitions update to a non-rolled
+  ; transaction - updated definition following adding rx txns through to
+  ; 2023-06-30 should update this definition to have date 2023-07-01,
+  ; which is a Saturday. 
+  freq: "SMS" ; semi-month start, 1st and 15th of every month
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate                  -120.00 USD
+  Expenses:Transport:Tram
+
+
+* Prevent rolling forwards a quarterly transfer between accounts
+
+2022-11-13 * "ETrade Transfer" "Transfering accumulated savings to other account"
+  ; As roll is defined as FALSE the next transaction will be dated
+  ; 2022-11-13 even through this is a Sunday.
+  freq: "3m"
+  roll: FALSE
+  Biens:US:BofA:Checking                           -4000 USD
+  Biens:US:ETrade:Cash
+
+
+* Including a 'final' transaction date
+
+2022-10-31 * "Chase" "Chase Hire Purchase"
+  freq: "BME"
+  ; No transaction will be created which would be dated (before any
+  ; rolling) later than 2022-11-30
+  final: 2022-11-30
+  Liabilities:US:Chase:HirePurchase                322.00 USD
+  Biens:US:BofA:Checking
+
+
+* Fortnightly income
+
+2022-10-07 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                         1350.60 USD
+  Biens:US:Vanguard:Cash                         1200.00 USD
+  Ingresos:US:BayBook:Salary                       -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife                  -24.32 USD
+  Expenses:Health:Life:GroupTermLife                24.32 USD
+  Expenses:Health:Dental:Insurance                   2.90 USD
+  Expenses:Health:Medical:Insurance                 27.38 USD
+  Expenses:Health:Vision:Insurance                  42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare                 106.62 USD
+  Expenses:Taxes:Y2020:US:Federal                 1062.92 USD
+  Expenses:Taxes:Y2020:US:State                    365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC                  174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                        1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                   281.54 USD
+  Biens:US:Federal:PreTax401k                   -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k      1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                            5 VACHR
+  Ingresos:US:BayBook:Vacation                           -5 VACHR
+
+
+* Fortnightly investments
+
+2022-10-07 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX                     50 VBMPX @@ 479.94 USD
+
+2022-10-07 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX                     13.3 RGAGX @@ 720.02 USD
+
+
+* Quarterly income
+
+2022-12-15 * "Dividend" "Dividends on portfolio"
+  freq: "3m"
+  Biens:US:ETrade:Cash                             29.59 USD
+  Ingresos:US:ETrade:GLD:Dividend
+
+
+;; ...enter definitions before this line.
+poptag #rx_txn

--- a/tests/resources/defs/defs_opts_221231.beancount
+++ b/tests/resources/defs/defs_opts_221231.beancount
@@ -1,0 +1,104 @@
+option "title" "Regular Expected Transaction Definitions"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+plugin "rx_txn_plugin"
+pushtag #rx_txn
+;; All accounts referenced by definitions should be defined on the main ledger.
+;; Enter definitions after this line...
+
+
+* Transactions between 'Biens:US:BofA:Checking' and other Assets accounts
+
+2023-02-13 * "ETrade Transfer" "Transfering accumulated savings to other account"
+  freq: "3m"
+  roll: FALSE
+  Biens:US:BofA:Checking  -4000 USD
+  Biens:US:ETrade:Cash
+
+
+* 'Biens:US:BofA:Checking' to Expenses and Liabilities
+
+2023-01-02 * "Account Fee" "Monthly bank fee"
+  freq: "BMS"
+  Biens:US:BofA:Checking   -4.00 USD
+  Expenses:Financial:Fees
+
+2023-01-05 * "EDISON" "Electricity, monthly fixed tarrif"
+  freq: "m"
+  Biens:US:BofA:Checking     -65.00 USD
+  Expenses:Home:Electricity
+
+2023-04-18 * "Erie" "Home insurance, yearly premium"
+  freq: "y"
+  Biens:US:BofA:Checking   -427.60 USD
+  Expenses:Home:Insurance
+
+2023-01-31 * "Slate" "Credit Card payment"
+  freq: "BME"
+  Biens:US:BofA:Checking      -250.00 USD
+  Liabilities:US:Chase:Slate
+
+2023-01-16 * "Verizon" "Telecoms, monthly variable" #you-can-inc-tags
+  freq: "m"
+  Biens:US:BofA:Checking  -55.00 USD
+  Expenses:Home:Phone
+
+
+* 'Biens:US:BofA:Checking' to various account types
+
+2023-01-13 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+
+* Income to 'Biens:US:ETrade:Cash'
+
+2023-03-15 * "Dividend" "Dividends on portfolio"
+  freq: "3m"
+  Biens:US:ETrade:Cash             29.59 USD
+  Ingresos:US:ETrade:GLD:Dividend
+
+
+* Transactions between 'Biens:US:Vanguard:Cash' and other Assets accounts
+
+2023-01-13 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2023-01-13 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+
+* 'Liabilities:US:Chase:Slate' to Expenses and Liabilities
+
+2023-01-01 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+
+
+
+;; ...enter definitions before this line.
+poptag #rx_txn

--- a/tests/resources/defs/ledger_opts.beancount
+++ b/tests/resources/defs/ledger_opts.beancount
@@ -1,0 +1,105 @@
+;; -*- mode: org; mode: beancount; -*-
+* Options
+
+option "title" "Example Beancount file"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+option "operating_currency" "USD"
+include "rx_opts.beancount"
+
+* Commodities
+
+
+1792-01-01 commodity USD
+  export: "CASH"
+  name: "US Dollar"
+
+1995-09-18 commodity VBMPX
+  export: "MUTF:VBMPX"
+  name: "Vanguard Total Bond Market Index Fund Institutional Plus Shares"
+  price: "USD:google/MUTF:VBMPX"
+
+2009-05-01 commodity RGAGX
+  export: "MUTF:RGAGX"
+  name: "American Funds The Growth Fund of America Class R-6"
+  price: "USD:google/MUTF:RGAGX"
+
+* Equity Accounts
+
+1980-05-12 open Equity:Opening-Balances
+
+* Banking
+
+2020-01-01 open Biens:US:BofA
+  address: "123 America Street, LargeTown, USA"
+  institution: "Bank of America"
+  phone: "+1.012.345.6789"
+2020-01-01 open Biens:US:BofA:Checking                        USD
+  account: "00234-48574897"
+
+2020-01-01 * "Opening Balance for checking account"
+  Biens:US:BofA:Checking                    3262.01 USD
+  Equity:Opening-Balances
+
+* Liabilities
+
+2020-05-12 open Liabilities:US:Chase:Slate                 USD
+2020-05-12 open Liabilities:US:Chase:HirePurchase          USD
+
+* Taxable Investments
+
+2020-01-01 open Biens:US:ETrade:Cash                      USD
+2020-01-01 open Ingresos:US:ETrade:GLD:Dividend              USD
+
+* Vanguard Investments
+
+2020-01-01 open Biens:US:Vanguard:VBMPX                     VBMPX
+  number: "882882"
+2020-01-01 open Biens:US:Vanguard:RGAGX                     RGAGX
+  number: "882882"
+2020-01-01 open Biens:US:Vanguard                            USD
+  address: "P.O. Box 1110, Valley Forge, PA 19482-1110"
+  institution: "Vanguard Group"
+  phone: "+1.800.523.1188"
+2020-01-01 open Biens:US:Vanguard:Cash                       USD
+  number: "882882"
+
+* Taxes
+
+2020-01-01 open Ingresos:US:Federal:PreTax401k                    IRAUSD
+2020-01-01 open Biens:US:Federal:PreTax401k                    IRAUSD
+
+* Sources of Income
+
+2020-01-01 open Ingresos:US:BayBook:Salary                      USD
+2020-01-01 open Ingresos:US:BayBook:GroupTermLife               USD
+2020-01-01 open Ingresos:US:BayBook:Vacation                    VACHR
+2020-01-01 open Biens:US:BayBook:Vacation                    VACHR
+2020-01-01 open Expenses:Vacation                               VACHR
+2020-01-01 open Expenses:Health:Life:GroupTermLife
+2020-01-01 open Expenses:Health:Medical:Insurance
+2020-01-01 open Expenses:Health:Dental:Insurance
+2020-01-01 open Expenses:Health:Vision:Insurance
+
+** Tax Year 2020
+
+2020-01-01 open Expenses:Taxes:Y2020:US:Federal:PreTax401k      IRAUSD
+2020-01-01 open Expenses:Taxes:Y2020:US:Medicare                USD
+2020-01-01 open Expenses:Taxes:Y2020:US:Federal                 USD
+2020-01-01 open Expenses:Taxes:Y2020:US:CityNYC                 USD
+2020-01-01 open Expenses:Taxes:Y2020:US:SDI                     USD
+2020-01-01 open Expenses:Taxes:Y2020:US:State                   USD
+2020-01-01 open Expenses:Taxes:Y2020:US:SocSec                  USD
+
+* Expenses
+
+2020-01-01 open Expenses:Home:Insurance
+2020-01-01 open Expenses:Home:Electricity
+2020-01-01 open Expenses:Home:Phone
+2020-01-01 open Expenses:Financial:Fees
+2020-01-01 open Expenses:Transport:Tram
+2020-01-01 open Expenses:Food:Restaurant
+2020-01-01 open Expenses:Food:Alcohol
+2020-01-01 open Expenses:Food:Coffee
+
+;; PREVIOUS TRANSACTIONS WOULD BE LISTED HERE

--- a/tests/resources/defs/rx_opts.beancount
+++ b/tests/resources/defs/rx_opts.beancount
@@ -1,0 +1,9 @@
+option "title" "Regular Expected Transactions Ledger"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+plugin "rx_txn_plugin"
+pushtag #rx_txn
+;; Transactions should not be manually added to this file.
+
+
+poptag #rx_txn

--- a/tests/resources/defs/rx_opts_221231.beancount
+++ b/tests/resources/defs/rx_opts_221231.beancount
@@ -1,0 +1,340 @@
+option "title" "Regular Expected Transactions Ledger"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+plugin "rx_txn_plugin"
+pushtag #rx_txn
+;; Transactions should not be manually added to this file.
+
+
+2022-10-03 * "Account Fee" "Monthly bank fee"
+  freq: "BMS"
+  Biens:US:BofA:Checking   -4.00 USD
+  Expenses:Financial:Fees
+
+2022-10-05 * "EDISON" "Electricity, monthly fixed tarrif"
+  freq: "m"
+  Biens:US:BofA:Checking     -65.00 USD
+  Expenses:Home:Electricity
+
+2022-10-07 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-10-07 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-10-07 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-10-17 * "Verizon" "Telecoms, monthly variable" #you-can-inc-tags
+  freq: "m"
+  Biens:US:BofA:Checking  -55.00 USD
+  Expenses:Home:Phone
+
+2022-10-17 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+2022-10-21 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-10-21 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-10-21 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-10-31 * "Slate" "Credit Card payment"
+  freq: "BME"
+  Biens:US:BofA:Checking      -250.00 USD
+  Liabilities:US:Chase:Slate
+
+2022-10-31 * "Chase" "Chase Hire Purchase"
+  freq: "BME"
+  final: 2022-11-30
+  Liabilities:US:Chase:HirePurchase  322.00 USD
+  Biens:US:BofA:Checking
+
+2022-11-01 * "Account Fee" "Monthly bank fee"
+  freq: "BMS"
+  Biens:US:BofA:Checking   -4.00 USD
+  Expenses:Financial:Fees
+
+2022-11-01 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+2022-11-04 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-11-04 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-11-04 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-11-07 * "EDISON" "Electricity, monthly fixed tarrif"
+  freq: "m"
+  Biens:US:BofA:Checking     -65.00 USD
+  Expenses:Home:Electricity
+
+2022-11-13 * "ETrade Transfer" "Transfering accumulated savings to other account"
+  freq: "3m"
+  roll: FALSE
+  Biens:US:BofA:Checking  -4000 USD
+  Biens:US:ETrade:Cash
+
+2022-11-15 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+2022-11-16 * "Verizon" "Telecoms, monthly variable" #you-can-inc-tags
+  freq: "m"
+  Biens:US:BofA:Checking  -55.00 USD
+  Expenses:Home:Phone
+
+2022-11-18 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-11-18 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-11-18 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-11-30 * "Slate" "Credit Card payment"
+  freq: "BME"
+  Biens:US:BofA:Checking      -250.00 USD
+  Liabilities:US:Chase:Slate
+
+2022-11-30 * "Chase" "Chase Hire Purchase"
+  freq: "BME"
+  final: 2022-11-30
+  Liabilities:US:Chase:HirePurchase  322.00 USD
+  Biens:US:BofA:Checking
+
+2022-12-01 * "Account Fee" "Monthly bank fee"
+  freq: "BMS"
+  Biens:US:BofA:Checking   -4.00 USD
+  Expenses:Financial:Fees
+
+2022-12-01 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+2022-12-02 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-12-02 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-12-02 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-12-05 * "EDISON" "Electricity, monthly fixed tarrif"
+  freq: "m"
+  Biens:US:BofA:Checking     -65.00 USD
+  Expenses:Home:Electricity
+
+2022-12-15 * "Metro" "Tram tickets, Metro Authority"
+  freq: "SMS"
+  test_meta: "You can include meta fields"
+  Liabilities:US:Chase:Slate  -120.00 USD
+  Expenses:Transport:Tram
+
+2022-12-15 * "Dividend" "Dividends on portfolio"
+  freq: "3m"
+  Biens:US:ETrade:Cash             29.59 USD
+  Ingresos:US:ETrade:GLD:Dividend
+
+2022-12-16 * "Verizon" "Telecoms, monthly variable" #you-can-inc-tags
+  freq: "m"
+  Biens:US:BofA:Checking  -55.00 USD
+  Expenses:Home:Phone
+
+2022-12-16 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-12-16 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-12-16 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+2022-12-30 * "Slate" "Credit Card payment"
+  freq: "BME"
+  Biens:US:BofA:Checking      -250.00 USD
+  Liabilities:US:Chase:Slate
+
+2022-12-30 * "BayBook" "Payroll"
+  freq: "2w"
+  Biens:US:BofA:Checking                       1350.60 USD
+  Biens:US:Vanguard:Cash                       1200.00 USD
+  Ingresos:US:BayBook:Salary                  -4615.38 USD
+  Ingresos:US:BayBook:GroupTermLife             -24.32 USD
+  Expenses:Health:Life:GroupTermLife             24.32 USD
+  Expenses:Health:Dental:Insurance                2.90 USD
+  Expenses:Health:Medical:Insurance              27.38 USD
+  Expenses:Health:Vision:Insurance               42.30 USD
+  Expenses:Taxes:Y2020:US:Medicare              106.62 USD
+  Expenses:Taxes:Y2020:US:Federal              1062.92 USD
+  Expenses:Taxes:Y2020:US:State                 365.08 USD
+  Expenses:Taxes:Y2020:US:CityNYC               174.92 USD
+  Expenses:Taxes:Y2020:US:SDI                     1.12 USD
+  Expenses:Taxes:Y2020:US:SocSec                281.54 USD
+  Biens:US:Federal:PreTax401k                 -1200.00 IRAUSD
+  Expenses:Taxes:Y2020:US:Federal:PreTax401k   1200.00 IRAUSD
+  Biens:US:BayBook:Vacation                          5 VACHR
+  Ingresos:US:BayBook:Vacation                      -5 VACHR
+
+2022-12-30 * "VBMPX" "Investing 40% of cash in VBMPX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:VBMPX  50 VBMPX @ 9.5988 USD
+
+2022-12-30 * "RGAGX" "Investing 60% of cash in RGAGX"
+  freq: "2w"
+  Biens:US:Vanguard:Cash
+  Biens:US:Vanguard:RGAGX  13.3 RGAGX @ 54.13684210526315789473684211 USD
+
+
+poptag #rx_txn

--- a/tests/resources/make/rx_opts.beancount
+++ b/tests/resources/make/rx_opts.beancount
@@ -1,0 +1,9 @@
+option "title" "Regular Expected Transactions Ledger"
+option "name_assets" "Biens"
+option "name_income" "Ingresos"
+plugin "rx_txn_plugin"
+pushtag #rx_txn
+;; Transactions should not be manually added to this file.
+
+
+poptag #rx_txn

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@
 
 import sys
 
+import pytest
+
 from beanahead import config as m
 
 from .conftest import also_get_stdout, also_get_stderr
@@ -21,9 +23,19 @@ from .conftest import also_get_stdout, also_get_stderr
 #   invalid-name: names in tests not expected to strictly conform with snake_case.
 
 
+def test_default_options_values(account_root_names_dflt):
+    """Verify default options values.
+
+    Also verifies value of constants.
+    """
+    assert m._print_stdout is True
+
+    assert m._account_root_names == account_root_names_dflt
+    assert m.DEFAULT_ACCOUNT_ROOT_NAMES == account_root_names_dflt
+
+
 def test_print_stream():
     """Tests output of print stream between stdout and stderr."""
-    assert m._print_stdout is True
     assert m.get_print_file() is sys.stdout
 
     def print_something():
@@ -45,3 +57,21 @@ def test_print_stream():
     assert prnt == "something\n"
     _, prnt = also_get_stderr(print_something)
     assert not prnt
+
+
+def test_account_name_roots(account_root_names_dflt):
+    """Tests methods for getting and setting account name roots."""
+    rtrn_dflt = m.get_account_root_names()
+    assert rtrn_dflt == account_root_names_dflt
+
+    names = {"name_assets": "Biens", "name_invalid": "Irrelevant"}
+    with pytest.raises(ValueError, match="'names' parameter can only contain keys:"):
+        m.set_account_root_names(names)
+    assert m.get_account_root_names() == account_root_names_dflt  # verify all unchnaged
+
+    names = {"name_assets": "Biens", "name_income": "Ingresos"}
+    set_names = m.set_account_root_names(names)
+    assert set_names == account_root_names_dflt | names
+
+    reset_names = m.reset_account_root_names()
+    assert reset_names == account_root_names_dflt == m.get_account_root_names()


### PR DESCRIPTION
Where previously assumed default values for the beancount 'name_*' options, now supports customised values.

Implementation now sets and gets these values via methods on the config module. The `utils.set_account_root_names` method has also been added to set these options from inspection of a beancount file.

Adds optional --main argument to the 'make' cli subcommand to take a ledger from which to read name options. The only other subcommand that requires knowledge of names is 'addrx' and this already required the main ledger to be passed.

Updates README to reflect new implementation.