### PR TITLE
Introduce configuration file for settings

### DIFF
--- a/examples/config/alt.ini
+++ b/examples/config/alt.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+# Account root names
+name-assets = Bienes
+name-liabilities = Obligaciones
+name-equity = Participaciones
+name-income = Ingresos
+name-expenses = Gastos
+
+print-stream = stderr  # from ('stdout', 'stderr')
+extension = bean  # Default extension for beancount files

--- a/examples/config/dflt.ini
+++ b/examples/config/dflt.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+# Account root names
+name-assets = Assets
+name-liabilities = Liabilities
+name-equity = Equity
+name-income = Income
+name-expenses = Expenses
+
+print-stream = stdout  # from ('stdout', 'stderr')
+extension = beancount  # Default extension for beancount files

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,6 @@ addopts = -rxXs --strict-markers --doctest-modules --capture=no
 testpaths = 
     tests
     src/beanahead/
+
+markers =
+    nosetdfltsettings: do not set settings to default config

--- a/tests/resources/config/alt.ini
+++ b/tests/resources/config/alt.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+# Account root names
+name-assets = Bienes
+name-liabilities = Obligaciones
+name-equity = Participaciones
+name-income = Ingresos
+name-expenses = Gastos
+
+print-stream = stderr  # from ('stdout', 'stderr')
+extension = bean  # Default extension for beancount files

--- a/tests/resources/config/alt_ext.ini
+++ b/tests/resources/config/alt_ext.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+# Account root names
+name-assets = Assets
+name-liabilities = Liabilities
+name-equity = Equity
+name-income = Income
+name-expenses = Expenses
+
+print-stream = stdout  # from ('stdout', 'stderr')
+extension = bean  # Default extension for beancount files

--- a/tests/resources/config/dflt.ini
+++ b/tests/resources/config/dflt.ini
@@ -1,0 +1,10 @@
+[DEFAULT]
+# Account root names
+name-assets = Assets
+name-liabilities = Liabilities
+name-equity = Equity
+name-income = Income
+name-expenses = Expenses
+
+print-stream = stdout  # from ('stdout', 'stderr')
+extension = beancount  # Default extension for beancount files

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,17 @@
 """Tests for `config` module."""
 
+from collections import abc
+import copy
+import pathlib
 import sys
+import textwrap
 
 import pytest
 
 from beanahead import config as m
+from beanahead.scripts import cli
 
-from .conftest import also_get_stdout, also_get_stderr
+from .conftest import set_cl_args
 
 # pylint: disable=missing-function-docstring, missing-type-doc, missing-class-docstring
 # pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
@@ -23,55 +28,206 @@ from .conftest import also_get_stdout, also_get_stderr
 #   invalid-name: names in tests not expected to strictly conform with snake_case.
 
 
-def test_default_options_values(account_root_names_dflt):
-    """Verify default options values.
+@pytest.fixture
+def dflt_config() -> abc.Iterator[str]:
+    """Default config file."""
+    yield textwrap.dedent(
+        """\
+        [DEFAULT]
+        # Account root names
+        name-assets = Assets
+        name-liabilities = Liabilities
+        name-equity = Equity
+        name-income = Income
+        name-expenses = Expenses
 
-    Also verifies value of constants.
+        print-stream = stdout  # from ('stdout', 'stderr')
+        extension = beancount  # Default extension for beancount files
+        """
+    )
+
+
+@pytest.mark.nosetdfltsettings
+@pytest.mark.usefixtures("reset_settings")
+def test_constants(account_root_names_dflt, encoding, dflt_config):
+    """Verify value of constants."""
+    assert m.ENCODING == "utf-8" == encoding
+    assert m.CONFIG_DIR == pathlib.Path("~/.config/beanahead").expanduser()
+    assert (
+        m.CONFIG_FILE == pathlib.Path("~/.config/beanahead").expanduser() / "config.ini"
+    )
+    assert m.SETTINGS_DFLTS == {
+        "name-assets": "Assets",
+        "name-liabilities": "Liabilities",
+        "name-equity": "Equity",
+        "name-income": "Income",
+        "name-expenses": "Expenses",
+        "print-stream": "stdout",
+        "extension": "beancount",
+    }
+    assert m.BC_DEFAULT_ACCOUNT_ROOT_NAMES == account_root_names_dflt
+    assert m.DFLT_CONFIG == dflt_config
+
+    assert len(m.PrintStream) == 2
+    assert m.PrintStream("stdout") == m.PrintStream["STDOUT"]
+    assert m.PrintStream("stderr") == m.PrintStream["STDERR"]
+
+    assert isinstance(m.SETTINGS, m.Settings)
+
+
+def test_print_config_file_address(capsys):
+    """Test the print_config_file_address function.
+
+    Also tests invocation from the command line.
     """
-    assert m._print_stdout is True
+    m.print_config_file_path()
+    expected_output = (
+        f"The beanahead configuration file can be found at:\n\t{m.CONFIG_FILE}\n"
+    )
+    assert capsys.readouterr().out == expected_output
+    set_cl_args("config")
+    cli.main()
+    assert capsys.readouterr().out == expected_output
 
-    assert m._account_root_names == account_root_names_dflt
-    assert m.DEFAULT_ACCOUNT_ROOT_NAMES == account_root_names_dflt
+
+def test_print_default_config(dflt_config, capsys):
+    m.print_default_config()
+    assert capsys.readouterr().out == dflt_config + "\n"
 
 
-def test_print_stream():
-    """Tests output of print stream between stdout and stderr."""
-    assert m.get_print_file() is sys.stdout
+@pytest.fixture
+def filepath_mp(monkeypatch, temp_dir) -> abc.Iterator[pathlib.Path]:
+    """Mock CONFIG_FILE to a temporary non-existent filepath."""
+    path_dir = temp_dir / "not_yet_a_dir"
+    monkeypatch.setattr("beanahead.config.CONFIG_DIR", path_dir)
+    filepath = path_dir / "config.ini"
+    monkeypatch.setattr("beanahead.config.CONFIG_FILE", filepath)
+    assert not path_dir.exists()
+    assert not filepath.exists()
+    yield filepath
 
-    def print_something():
-        print("something", file=m.get_print_file())
 
-    _, prnt = also_get_stdout(print_something)
-    assert prnt == "something\n"
-    _, prnt = also_get_stderr(print_something)
-    assert not prnt
+def test__write_reset_config(filepath_mp, dflt_config, capsys):
+    """Tests _write_config() and reset_config().
 
-    m.set_print_stderr()
-    _, prnt = also_get_stdout(print_something)
-    assert not prnt
-    _, prnt = also_get_stderr(print_something)
-    assert prnt == "something\n"
+    Also tests invocation from the command line.
+    """
+    path = filepath_mp
+    assert not filepath_mp.exists()
+    m._write_config()
+    assert path.read_text() == dflt_config
 
-    m.set_print_stdout()
-    _, prnt = also_get_stdout(print_something)
-    assert prnt == "something\n"
-    _, prnt = also_get_stderr(print_something)
-    assert not prnt
+    path.write_text("Overwritting config file")
+    assert path.read_text() == "Overwritting config file"
+    m.reset_config()
+    assert path.read_text() == dflt_config
+
+    path.write_text("Overwritting previous config file")
+    set_cl_args("config --reset")
+    cli.main()
+    expected = (
+        "The contents of the configuration file have been reset to default values."
+    )
+    assert capsys.readouterr().out.startswith(expected)
+    assert path.read_text() == dflt_config
+
+
+def test_parse_config(config_dflt, settings_dflt, config_alt, settings_alt):
+    """Test parsing of configuration file."""
+    # Test valid configuration
+    assert m.parse_config(config_dflt) == settings_dflt
+    assert m.parse_config(config_alt) == settings_alt
+
+    valid_config = copy.copy(config_dflt)
+    # verify leading and trailing whitespace ok and can include . prefix
+    valid_config["extension"] = "  .beancount "
+    assert m.parse_config(valid_config) == settings_dflt
+
+    # Test invalid keys
+    invalid_config = copy.copy(config_dflt)
+    invalid_config["invalid_key"] = "value"
+    match = (
+        "The configuration file includes the following invalid options:"
+        " '{'invalid_key'}'.\nThese options will be ignored."
+    )
+    with pytest.warns(m.ConfigInvalidOptionsWarning, match=match):
+        parsed_settings = m.parse_config(invalid_config)
+    assert parsed_settings == settings_dflt  # Invalid keys should be ignored
+
+    # Test invalid value for 'print-stream'
+    invalid_print_stream = copy.copy(config_dflt)
+    invalid_print_stream["print-stream"] = "invalid_stream"
+    with pytest.warns(
+        m.ConfigInvalidValueWarning,
+        match="'invalid_stream' is not a valid value for the configuration option print-stream",
+    ):
+        parsed_settings = m.parse_config(invalid_print_stream)
+    assert parsed_settings == settings_dflt  # default value should have been used
+    assert parsed_settings.print_stream == m.PrintStream.STDOUT  # Double check
+
+    # Test invalid value with whitespace within
+    invalid_config = copy.copy(config_dflt)
+    invalid_config["name-assets"] = "Assets Root"
+    with pytest.warns(
+        m.ConfigInvalidValueWarning,
+        match=(
+            "'Assets Root' is not a valid value for the configuration"
+            " option name-assets"
+        ),
+    ):
+        parsed_settings = m.parse_config(invalid_config)
+    assert parsed_settings == settings_dflt  # Check all as default values
+    assert parsed_settings.name_assets == "Assets"  # Double check default value used
+
+
+@pytest.mark.usefixtures("config_path_mp_alt")
+def test_load_config(config_alt):
+    """Test loading of configuration section from configuration file."""
+    assert m.load_config() == config_alt
+
+
+@pytest.mark.usefixtures("config_path_mp_alt")
+def test_get_settings_from_config(settings_alt):
+    """Test loading of settings from configuration file."""
+    assert m.get_settings_from_config() == settings_alt
+
+
+def test_default_print_stream(capsys):
+    """Verify default print stream and effect."""
+    assert m.SETTINGS.print_stream == m.PrintStream.STDOUT
+    assert m.SETTINGS.print_to is sys.stdout
+    print("something", file=m.SETTINGS.print_to)
+    capture = capsys.readouterr()
+    assert capture.out == "something\n"
+    assert not capture.err
+
+
+@pytest.mark.usefixtures("settings_alt_prnt_mp")
+def test_alt_print_stream(capsys):
+    """Verify alternative print setting and effect."""
+    assert m.SETTINGS.print_stream == m.PrintStream.STDERR
+    assert m.SETTINGS.print_to is sys.stderr
+    print("something", file=m.SETTINGS.print_to)
+    capture = capsys.readouterr()
+    assert not capture.out
+    assert capture.err == "something\n"
 
 
 def test_account_name_roots(account_root_names_dflt):
-    """Tests methods for getting and setting account name roots."""
+    """Tests `get_account_root_names` and `set_account_root_names`."""
     rtrn_dflt = m.get_account_root_names()
     assert rtrn_dflt == account_root_names_dflt
 
     names = {"name_assets": "Biens", "name_invalid": "Irrelevant"}
-    with pytest.raises(ValueError, match="'names' parameter can only contain keys:"):
+    keys = {k.replace("-", "_") for k in m.SETTINGS_DFLTS}
+    match = (
+        f"'names' parameter can only contain keys: {keys}, although received 'names'"
+        " included keys: {'name_invalid'}."
+    )
+    with pytest.raises(ValueError, match=match):
         m.set_account_root_names(names)
     assert m.get_account_root_names() == account_root_names_dflt  # verify all unchnaged
 
     names = {"name_assets": "Biens", "name_income": "Ingresos"}
-    set_names = m.set_account_root_names(names)
-    assert set_names == account_root_names_dflt | names
-
-    reset_names = m.reset_account_root_names()
-    assert reset_names == account_root_names_dflt == m.get_account_root_names()
+    m.set_account_root_names(names)
+    assert m.get_account_root_names() == account_root_names_dflt | names

--- a/tests/test_rx_txns.py
+++ b/tests/test_rx_txns.py
@@ -16,7 +16,7 @@ from beanahead import errors, config
 from beanahead.scripts import cli
 
 from . import cmn
-from .conftest import set_cl_args, also_get_stdout
+from .conftest import set_cl_args
 
 # pylint: disable=missing-function-docstring, missing-type-doc, missing-class-docstring
 # pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
@@ -464,6 +464,7 @@ class TestAdmin:
         defs_opts_221231_content,
         rx_opts_221231_content,
         encoding,
+        capsys,
     ):
         """Test for initial generation of rx txns.
 
@@ -515,13 +516,13 @@ class TestAdmin:
         assert admin.rx_files == [defs_path, rx_path]
         assert admin.rx_txns == []
 
-        _, output = also_get_stdout(admin.add_txns, datetime.date(2022, 12, 31))
+        admin.add_txns(datetime.date(2022, 12, 31))
         expected_output = (
             "42 transactions have been added to the ledger 'rx'.\n"
             "Definitions on 'defs' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out.endswith(expected_output)
         assert defs_path.read_text(encoding) == defs_221231_content
         assert rx_path.read_text(encoding) == rx_221231_content
 
@@ -531,13 +532,13 @@ class TestAdmin:
         assert admin.rx_files == [defs_path, rx_path]
         cmn.assert_txns_equal(admin.rx_txns, rx_txns_221231)
 
-        _, output = also_get_stdout(admin.add_txns, datetime.date(2023, 6, 30))
+        admin.add_txns(datetime.date(2023, 6, 30))
         expected_output = (
             "80 transactions have been added to the ledger 'rx'."
             "\nDefinitions on 'defs' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out == expected_output
         assert defs_path.read_text(encoding) == defs_230630_content
         assert rx_path.read_text(encoding) == rx_230630_content
 
@@ -570,13 +571,13 @@ class TestAdmin:
         assert admin_opts.rx_files == [defs_opts_path, rx_opts_path]
         assert admin_opts.rx_txns == []
 
-        _, output = also_get_stdout(admin_opts.add_txns, datetime.date(2022, 12, 31))
+        admin_opts.add_txns(datetime.date(2022, 12, 31))
         expected_output = (
             "42 transactions have been added to the ledger 'rx_opts'.\n"
             "Definitions on 'defs_opts' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out == expected_output
         assert defs_opts_path.read_text(encoding) == defs_opts_221231_content
         assert rx_opts_path.read_text(encoding) == rx_opts_221231_content
 
@@ -585,8 +586,6 @@ class TestAdmin:
         assert set(admin_opts.payees) == def_payees
         assert admin_opts.rx_files == [defs_opts_path, rx_opts_path]
         cmn.assert_txns_equal(admin_opts.rx_txns, rx_opts_txns_221231)
-
-        config.reset_account_root_names()
 
     @pytest.mark.usefixtures("cwd_as_temp_dir")
     def test_cli_addrx(
@@ -600,6 +599,7 @@ class TestAdmin:
         defs_opts_221231_content,
         rx_opts_221231_content,
         encoding,
+        capsys,
     ):
         """Test calling `Admin.add_txns` via cli.
 
@@ -609,24 +609,24 @@ class TestAdmin:
         rx_path = filepaths_defs_copy_0["rx"]
 
         set_cl_args("addrx defs rx ledger -e 2022-12-31")
-        _, output = also_get_stdout(cli.main)
+        cli.main()
         expected_output = (
             "42 transactions have been added to the ledger 'rx'.\n"
             "Definitions on 'defs' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out == expected_output
         assert defs_path.read_text(encoding) == defs_221231_content
         assert rx_path.read_text(encoding) == rx_221231_content
 
         set_cl_args("addrx defs rx ledger -e 2023-06-30")
-        _, output = also_get_stdout(cli.main)
+        cli.main()
         expected_output = (
             "80 transactions have been added to the ledger 'rx'."
             "\nDefinitions on 'defs' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out == expected_output
         assert defs_path.read_text(encoding) == defs_230630_content
         assert rx_path.read_text(encoding) == rx_230630_content
 
@@ -635,12 +635,12 @@ class TestAdmin:
         rx_opts_path = filepaths_defs_opts_copy_0["rx"]
 
         set_cl_args("addrx defs_opts rx_opts ledger_opts -e 2022-12-31")
-        _, output = also_get_stdout(cli.main)
+        cli.main()
         expected_output = (
             "42 transactions have been added to the ledger 'rx_opts'.\n"
             "Definitions on 'defs_opts' have been updated to reflect the"
             " most recent transactions.\n"
         )
-        assert output == expected_output
+        assert capsys.readouterr().out == expected_output
         assert defs_opts_path.read_text(encoding) == defs_opts_221231_content
         assert rx_opts_path.read_text(encoding) == rx_opts_221231_content


### PR DESCRIPTION
Provides for setting options via an ini configuration file at '~/.config/beanahead/config.ini'.

Also, lifts restriction on beancount files having the .beancount extension. A beancount file can now be defined at the command line with any extension; if an extension is not included then the default extension will be assumed (as defined in the configuration file). (Fixes #23)

Adds 'config.print_config_file_path' function to print path to configuration file, also available via cli: `beanahead config`.
Adds 'config.reset_config' to reset configuration file to default values, also available via cli: `beanahead config --reset`.

Options:
- Print stream can now only be set via the configuration file.
- Root account names can now be set via the configuration file although can also still set via either of:
  - passing --main option to the 'addrx' or 'recon' subcommands
  - programmatically, via `config.set_account_root_names`.
- Default beancount file extension can now be set via the configuration file (.beancount by default).

Also removes the 'also_get_stdout' and 'also_get_stderr' test functions from conftest module in favour of using the pytest fixture 'capsys'.

Update documentation and updates / includes tests for all changes.