### PR TITLE
Fix narration value of reconciled entries

### DIFF
--- a/src/beanahead/reconcile.py
+++ b/src/beanahead/reconcile.py
@@ -455,7 +455,7 @@ def update_new_txn(new_txn: Transaction, x_txn: Transaction) -> Transaction:
     x_txn = utils.reverse_automatic_balancing(x_txn)
     new_txn = utils.reverse_automatic_balancing(new_txn)
 
-    if not new_txn.narration:
+    if x_txn.narration:
         new_txn = new_txn._replace(narration=x_txn.narration)
 
     if tags_to_add := x_txn.tags - utils.TAGS_X:

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -884,7 +884,7 @@ class TestUpdateNewTxn:
         and `x_txn` the corresponding expected transaction.
         """
         assert txn.date == new_txn.date == datetime.date(2022, 10, 18)
-        assert txn.narration == new_txn.narration == "new_txn narration"
+        assert txn.narration == x_txn.narration == "x_txn narration"
         assert txn.tags == frozenset(["x_txn_tag", "new_tag"])
 
         assert len(txn.meta) == 6


### PR DESCRIPTION
Changes how narration field is defined on reconciled entries so that it now agrees with documentation. Now narration value is always set as defined on the expected txn (previously this was only the case if the narration was not otherwise defined on the incoming txn). If narration is not defined on the expected txn then any narration defined on the incoming txn will be preserved.